### PR TITLE
Install as dev only

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Easily run multiple Laravel Sail applications at the same time locally with cust
 You can install the package via composer:
 
 ```bash
-composer require aschmelyun/fleet
+composer require aschmelyun/fleet --dev
 ```
 
 ## Getting Started


### PR DESCRIPTION
Since [Sail](https://laravel.com/docs/10.x/sail#introduction) is only a developer environment, recommending the package as a dev only dependency should be a good idea.