### PR TITLE
Adds SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ And your site will be available at the domain you provided!
 
 > Note: If you chose a domain that doesn't end in `.localhost`, you will need to add an entry to your hosts file to direct traffic to 127.0.0.1
 
+## Local SSL
+
+Fleet supports local SSL on your custom domains through the power of [mkcert](https://mkcert.dev). After you've installed it on your machine, you can use the `--ssl` option when using the `fleet:add` command to enable it for your application.
+
+```bash
+php artisan fleet:add my-app.localhost --ssl
+```
+
+A local certificate will be generated and stored in `~/.config/mkcert/certs`. After spinning up your site with Sail, your specified domain will have https enabled.
+
 ## Additional Usage
 
 By default, whenever you use `fleet:add`, a Docker network and container are both started to handle the traffic from your local domain name(s).

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,7 +6,6 @@ parameters:
     paths:
         - src
         - config
-        - database
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true

--- a/src/Commands/FleetAddCommand.php
+++ b/src/Commands/FleetAddCommand.php
@@ -20,7 +20,7 @@ class FleetAddCommand extends Command
     {
         // set the domain to the one the user provided, or ask what it should be
         $domain = $this->argument('domain');
-        if (!$domain) {
+        if (! $domain) {
             $domain = $this->ask('What domain name would you like to use for this app?', 'laravel.localhost');
         }
 
@@ -30,13 +30,13 @@ class FleetAddCommand extends Command
         }
 
         // determine if laravel/sail is a required-dev package in the root composer file
-        if (!InstalledVersions::isInstalled('laravel/sail')) {
+        if (! InstalledVersions::isInstalled('laravel/sail')) {
             $this->error(' Laravel Sail is required for this package');
             $this->line(' For more information, check out https://laravel.com/docs/sail#installation');
         }
 
         // if the docker-compose.yml file isn't available, publish it
-        if (!file_exists(base_path('docker-compose.yml')) && !file_exists(base_path('docker-compose.backup.yml'))) {
+        if (! file_exists(base_path('docker-compose.yml')) && ! file_exists(base_path('docker-compose.backup.yml'))) {
             $this->info('No docker-compose.yml file available, running sail:install...');
             $this->call('sail:install');
         }
@@ -58,16 +58,17 @@ class FleetAddCommand extends Command
             $filesystem->writeToEnvFile('APP_PORT', $port);
         } catch (\Exception $e) {
             $this->error($e->getMessage());
+
             return self::FAILURE;
         }
 
         // add a modified docker-compose.yml file to include traefik labels
         $file = base_path('docker-compose.backup.yml');
-        if (!file_exists($file)) {
+        if (! file_exists($file)) {
             $file = base_path('docker-compose.yml');
         }
 
-        if (!file_exists($file)) {
+        if (! file_exists($file)) {
             $this->error('A docker-compose.yml file or a docker-compose.backup.yml file does not exist');
 
             return self::FAILURE;
@@ -84,6 +85,7 @@ class FleetAddCommand extends Command
             } catch (\Exception $e) {
                 $this->error($e->getMessage());
                 $this->line('For more information, try checking out the documentation at mkcert.dev');
+
                 return self::FAILURE;
             }
 
@@ -91,6 +93,7 @@ class FleetAddCommand extends Command
                 $filesystem->createSslConfig($domain);
             } catch (\Exception $e) {
                 $this->error($e->getMessage());
+
                 return self::FAILURE;
             }
 

--- a/src/Commands/FleetRemoveCommand.php
+++ b/src/Commands/FleetRemoveCommand.php
@@ -2,6 +2,7 @@
 
 namespace Aschmelyun\Fleet\Commands;
 
+use Aschmelyun\Fleet\Support\Filesystem;
 use Illuminate\Console\Command;
 use Symfony\Component\Yaml\Yaml;
 
@@ -11,7 +12,7 @@ class FleetRemoveCommand extends Command
 
     public $description = 'Removes Fleet support from the current application';
 
-    public function handle(): int
+    public function handle(Filesystem $filesystem): int
     {
         // determine if fleet is installed, return a response if not
         $file = base_path('docker-compose.yml');
@@ -40,37 +41,34 @@ class FleetRemoveCommand extends Command
         }
 
         // remove all fleet additions to the .env and docker-compose.yml files
-        $file = base_path('.env');
-        if (file_exists($file)) {
-            $env = file_get_contents($file);
-            $env = explode("\n", $env);
-
-            foreach ($env as $index => $line) {
-                if (str_starts_with($line, 'APP_PORT')) {
-                    unset($env[$index]);
-                }
-            }
-
-            file_put_contents(base_path('.env'), implode("\n", $env));
-        }
-
-        $service = $yaml['services'][array_keys($yaml['services'])[0]];
-        unset($yaml['services'][array_keys($yaml['services'])[0]]);
-
-        $yaml['services'] = ['laravel.test' => $service, ...$yaml['services']];
-
-        $yaml['services']['laravel.test']['networks'] = ['sail'];
-        unset($yaml['services']['laravel.test']['labels']);
-
-        $yaml['services']['laravel.test']['ports'][] = '${APP_PORT:-80}:80';
-
-        unset($yaml['networks']['fleet']);
-
-        file_put_contents(base_path('docker-compose.yml'), Yaml::dump($yaml, 6));
+        $filesystem->removeFromEnvFile('APP_PORT');
+        $this->removeYamlFromDockerCompose($yaml);
 
         // return info back to the user
         $this->info(' ✨ All done! Fleet has been successfully removed from this application');
 
         return self::SUCCESS;
+    }
+
+    private function removeYamlFromDockerCompose(array $yaml): void
+    {
+        // remove the custom domain as the first service key
+        $service = $yaml['services'][array_keys($yaml['services'])[0]];
+        unset($yaml['services'][array_keys($yaml['services'])[0]]);
+
+        // and replace it with the default, laravel.test
+        $yaml['services'] = ['laravel.test' => $service, ...$yaml['services']];
+
+        // reset the networks and labels
+        $yaml['services']['laravel.test']['networks'] = ['sail'];
+        unset($yaml['services']['laravel.test']['labels']);
+
+        // reset the ports
+        $yaml['services']['laravel.test']['ports'][] = '${APP_PORT:-80}:80';
+
+        // remove the fleet network
+        unset($yaml['networks']['fleet']);
+
+        file_put_contents(base_path('docker-compose.yml'), Yaml::dump($yaml, 6));
     }
 }

--- a/src/Commands/FleetRemoveCommand.php
+++ b/src/Commands/FleetRemoveCommand.php
@@ -15,14 +15,14 @@ class FleetRemoveCommand extends Command
     {
         // determine if fleet is installed, return a response if not
         $file = base_path('docker-compose.yml');
-        if (!file_exists($file)) {
+        if (! file_exists($file)) {
             $this->error('A docker-compose.yml file does not exist');
 
             return self::FAILURE;
         }
 
         $yaml = Yaml::parseFile($file);
-        if (!isset($yaml['networks']['fleet'])) {
+        if (! isset($yaml['networks']['fleet'])) {
             $this->info(' Fleet is not currently installed on this application');
 
             return self::SUCCESS;

--- a/src/Commands/FleetStartCommand.php
+++ b/src/Commands/FleetStartCommand.php
@@ -31,7 +31,7 @@ class FleetStartCommand extends Command
         }
 
         // just in case the mkcert directory doesn't exist, create it
-        $process = Fleet::process("mkdir -p ~/.config/mkcert");
+        Fleet::makeSslDirectories();
 
         $homeDirectory = new Process(['sh', '-c', 'echo $HOME']);
         $homeDirectory->run();

--- a/src/Commands/FleetStartCommand.php
+++ b/src/Commands/FleetStartCommand.php
@@ -15,7 +15,7 @@ class FleetStartCommand extends Command
     public function handle(Filesystem $filesystem, Docker $docker): int
     {
         // is the fleet docker network running? if not, start it up
-        if (!$docker->getNetwork('fleet')) {
+        if (! $docker->getNetwork('fleet')) {
             $this->info('No Fleet network, creating one...');
 
             try {
@@ -34,7 +34,7 @@ class FleetStartCommand extends Command
         $filesystem->createSslDirectories();
 
         // is the fleet traefik container running? if not, start it up
-        if (!$docker->getContainer('fleet')) {
+        if (! $docker->getContainer('fleet')) {
             $this->info('No Fleet container, spinning it up...');
 
             try {

--- a/src/Commands/FleetStopCommand.php
+++ b/src/Commands/FleetStopCommand.php
@@ -13,7 +13,7 @@ class FleetStopCommand extends Command
 
     public function handle(): int
     {
-        if (!$this->confirm('This will stop and remove all Sail instances running on the Fleet network, do you want to continue?')) {
+        if (! $this->confirm('This will stop and remove all Sail instances running on the Fleet network, do you want to continue?')) {
             return self::SUCCESS;
         }
 
@@ -25,7 +25,7 @@ class FleetStopCommand extends Command
             $this->line("Removing container {$id}");
 
             $process = Fleet::process("docker rm -f {$id}");
-            if (!$process->isSuccessful()) {
+            if (! $process->isSuccessful()) {
                 $this->error("Error removing container {$id}");
 
                 return self::FAILURE;

--- a/src/Fleet.php
+++ b/src/Fleet.php
@@ -22,10 +22,4 @@ class Fleet
 
         return $process;
     }
-
-    public static function makeSslDirectories(): void
-    {
-        self::process("mkdir -p ~/.config/mkcert/certs");
-        self::process("mkdir -p ~/.config/mkcert/conf");
-    }
 }

--- a/src/Fleet.php
+++ b/src/Fleet.php
@@ -22,4 +22,10 @@ class Fleet
 
         return $process;
     }
+
+    public static function makeSslDirectories(): void
+    {
+        self::process("mkdir -p ~/.config/mkcert/certs");
+        self::process("mkdir -p ~/.config/mkcert/conf");
+    }
 }

--- a/src/FleetServiceProvider.php
+++ b/src/FleetServiceProvider.php
@@ -6,11 +6,19 @@ use Aschmelyun\Fleet\Commands\FleetAddCommand;
 use Aschmelyun\Fleet\Commands\FleetRemoveCommand;
 use Aschmelyun\Fleet\Commands\FleetStartCommand;
 use Aschmelyun\Fleet\Commands\FleetStopCommand;
+use Aschmelyun\Fleet\Support\Docker;
+use Aschmelyun\Fleet\Support\Filesystem;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
 class FleetServiceProvider extends PackageServiceProvider
 {
+    public function registeringPackage()
+    {
+        $this->app->singleton(Docker::class);
+        $this->app->singleton(Filesystem::class);
+    }
+
     public function configurePackage(Package $package): void
     {
         $package

--- a/src/Support/Docker.php
+++ b/src/Support/Docker.php
@@ -3,7 +3,6 @@
 namespace Aschmelyun\Fleet\Support;
 
 use Aschmelyun\Fleet\Fleet;
-use Aschmelyun\Fleet\Support\Filesystem;
 
 class Docker
 {
@@ -43,7 +42,7 @@ class Docker
     public function startFleetTraefikContainer(): void
     {
         $homeDirectory = app(Filesystem::class)->getHomeDirectory();
-        
+
         Fleet::process(
             "docker run -d -p 8080:8080 -p 80:80 -p 443:443 --network=fleet -v /var/run/docker.sock:/var/run/docker.sock -v {$homeDirectory}/.config/mkcert:/etc/traefik --name=fleet traefik:v2.9 --api.insecure=true --providers.docker --entryPoints.web.address=:80 --entryPoints.websecure.address=:443 --providers.file.directory=/etc/traefik/conf --providers.file.watch=true",
             true

--- a/src/Support/Docker.php
+++ b/src/Support/Docker.php
@@ -28,6 +28,11 @@ class Docker
         throw new \Exception('Could not create Docker network');
     }
 
+    public function removeNetwork(string $name): void
+    {
+        Fleet::process("docker network rm {$name}");
+    }
+
     public function getContainer(string $name): ?string
     {
         $process = Fleet::process("docker ps --filter name=^{$name}$ --format '{{.ID}}'");
@@ -37,6 +42,16 @@ class Docker
         }
 
         return null;
+    }
+
+    public function removeContainers(string $network): void
+    {
+        $process = Fleet::process("docker ps -a --filter network={$network} --format {{.ID}}");
+
+        $ids = explode("\n", $process->getOutput());
+        foreach (array_filter($ids) as $id) {
+            Fleet::process("docker rm -f {$id}");
+        }
     }
 
     public function startFleetTraefikContainer(): void

--- a/src/Support/Docker.php
+++ b/src/Support/Docker.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Aschmelyun\Fleet\Support;
+
+use Aschmelyun\Fleet\Fleet;
+use Aschmelyun\Fleet\Support\Filesystem;
+
+class Docker
+{
+    public function getNetwork(string $name): ?string
+    {
+        $process = Fleet::process("docker network ls --filter name=^{$name}$ --format '{{.ID}}'");
+
+        if ($process->isSuccessful()) {
+            return trim($process->getOutput());
+        }
+
+        return null;
+    }
+
+    public function createNetwork(string $name): string
+    {
+        $process = Fleet::process("docker network create {$name}");
+
+        if ($process->isSuccessful()) {
+            return trim($process->getOutput());
+        }
+
+        throw new \Exception('Could not create Docker network');
+    }
+
+    public function getContainer(string $name): ?string
+    {
+        $process = Fleet::process("docker ps --filter name=^{$name}$ --format '{{.ID}}'");
+
+        if ($process->isSuccessful()) {
+            return trim($process->getOutput());
+        }
+
+        return null;
+    }
+
+    public function startFleetTraefikContainer(): void
+    {
+        $homeDirectory = app(Filesystem::class)->getHomeDirectory();
+        
+        Fleet::process(
+            "docker run -d -p 8080:8080 -p 80:80 -p 443:443 --network=fleet -v /var/run/docker.sock:/var/run/docker.sock -v {$homeDirectory}/.config/mkcert:/etc/traefik --name=fleet traefik:v2.9 --api.insecure=true --providers.docker --entryPoints.web.address=:80 --entryPoints.websecure.address=:443 --providers.file.directory=/etc/traefik/conf --providers.file.watch=true",
+            true
+        );
+    }
+}

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Aschmelyun\Fleet\Support;
+
+use Symfony\Component\Process\Process;
+use Symfony\Component\Yaml\Yaml;
+use Aschmelyun\Fleet\Fleet;
+
+class Filesystem
+{
+    public function makeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            mkdir($path, 0755, true);
+        }
+    }
+
+    public function createSslDirectories(): void
+    {
+        $this->makeDirectory($this->getHomeDirectory() . '/.config/mkcert/certs');
+        $this->makeDirectory($this->getHomeDirectory() . '/.config/mkcert/conf');
+    }
+
+    public function getHomeDirectory(): string
+    {
+        $homeDirectory = new Process(['sh', '-c', 'echo $HOME']);
+        $homeDirectory->run();
+
+        return trim($homeDirectory->getOutput());
+    }
+
+    public function writeToEnvFile(string $key, string $value): void
+    {
+        $file = base_path('.env');
+        if (!file_exists($file)) {
+            throw new \Exception('Application .env file is missing, can\'t continue');
+        }
+
+        $env = file_get_contents($file);
+        $env = explode("\n", $env);
+
+        $filteredEnvAppPort = array_filter($env, fn ($line) => str_starts_with($line, $key));
+        if (!empty($filteredEnvAppPort)) {
+            $env[key($filteredEnvAppPort)] = "{$key}={$value}";
+        } else {
+            $insert = ["{$key}={$value}"];
+            array_splice($env, 5, 0, $insert);
+        }
+
+        file_put_contents(base_path('.env'), implode("\n", $env));
+    }
+
+    public function createCertificates(string $domain): void
+    {
+        $this->createSslDirectories();
+
+        $process = Fleet::process("mkcert -install");
+        if (!$process->isSuccessful()) {
+            throw new \Exception('mkcert is not installed or configured incorrectly, please install it and try again');
+        }
+
+        $process = Fleet::process(
+            "mkcert -cert-file {$this->getHomeDirectory()}/.config/mkcert/certs/{$domain}.crt -key-file {$this->getHomeDirectory()}/.config/mkcert/certs/{$domain}.key {$domain}"
+        );
+        if (!$process->isSuccessful()) {
+            throw new \Exception('mkcert is not installed or configured incorrectly, please install it and try again');
+        }
+    }
+
+    public function createSslConfig(string $domain): void
+    {
+        $sslConfigFile = "{$this->getHomeDirectory()}/.config/mkcert/conf/ssl.yml";
+        $ssl = [];
+        if (file_exists($sslConfigFile)) {
+            $ssl = Yaml::parseFile($sslConfigFile);
+        }
+
+        $ssl['tls']['certificates'][] = [
+            'certFile' => "/etc/traefik/certs/{$domain}.crt",
+            'keyFile' => "/etc/traefik/certs/{$domain}.key",
+        ];
+
+        file_put_contents($sslConfigFile, Yaml::dump($ssl, 6));
+    }
+}

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -2,23 +2,23 @@
 
 namespace Aschmelyun\Fleet\Support;
 
+use Aschmelyun\Fleet\Fleet;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Yaml\Yaml;
-use Aschmelyun\Fleet\Fleet;
 
 class Filesystem
 {
     public function makeDirectory(string $path): void
     {
-        if (!is_dir($path)) {
+        if (! is_dir($path)) {
             mkdir($path, 0755, true);
         }
     }
 
     public function createSslDirectories(): void
     {
-        $this->makeDirectory($this->getHomeDirectory() . '/.config/mkcert/certs');
-        $this->makeDirectory($this->getHomeDirectory() . '/.config/mkcert/conf');
+        $this->makeDirectory($this->getHomeDirectory().'/.config/mkcert/certs');
+        $this->makeDirectory($this->getHomeDirectory().'/.config/mkcert/conf');
     }
 
     public function getHomeDirectory(): string
@@ -32,7 +32,7 @@ class Filesystem
     public function writeToEnvFile(string $key, string $value): void
     {
         $file = base_path('.env');
-        if (!file_exists($file)) {
+        if (! file_exists($file)) {
             throw new \Exception('Application .env file is missing, can\'t continue');
         }
 
@@ -40,7 +40,7 @@ class Filesystem
         $env = explode("\n", $env);
 
         $filteredEnvAppPort = array_filter($env, fn ($line) => str_starts_with($line, $key));
-        if (!empty($filteredEnvAppPort)) {
+        if (! empty($filteredEnvAppPort)) {
             $env[key($filteredEnvAppPort)] = "{$key}={$value}";
         } else {
             $insert = ["{$key}={$value}"];
@@ -54,15 +54,15 @@ class Filesystem
     {
         $this->createSslDirectories();
 
-        $process = Fleet::process("mkcert -install");
-        if (!$process->isSuccessful()) {
+        $process = Fleet::process('mkcert -install');
+        if (! $process->isSuccessful()) {
             throw new \Exception('mkcert is not installed or configured incorrectly, please install it and try again');
         }
 
         $process = Fleet::process(
             "mkcert -cert-file {$this->getHomeDirectory()}/.config/mkcert/certs/{$domain}.crt -key-file {$this->getHomeDirectory()}/.config/mkcert/certs/{$domain}.key {$domain}"
         );
-        if (!$process->isSuccessful()) {
+        if (! $process->isSuccessful()) {
             throw new \Exception('mkcert is not installed or configured incorrectly, please install it and try again');
         }
     }

--- a/src/Support/Filesystem.php
+++ b/src/Support/Filesystem.php
@@ -50,6 +50,22 @@ class Filesystem
         file_put_contents(base_path('.env'), implode("\n", $env));
     }
 
+    public function removeFromEnvFile(string $key): void
+    {
+        $file = base_path('.env');
+        if (file_exists($file)) {
+            $env = explode("\n", file_get_contents($file));
+
+            foreach ($env as $index => $line) {
+                if (str_starts_with($line, $key)) {
+                    unset($env[$index]);
+                }
+            }
+
+            file_put_contents(base_path('.env'), implode("\n", $env));
+        }
+    }
+
     public function createCertificates(string $domain): void
     {
         $this->createSslDirectories();


### PR DESCRIPTION
Fixes #3, adds SSL support.

Using [mkcert](https://mkcert.dev) commands, a local certificate is generated and then used within the Traefik container created for Fleet. Visiting your custom domain after spinning up your Sail site can then be accessed under https without any warnings or errors from your browser.

Usage: `php artisan fleet:add my-site.localhost --ssl`.