### PR TITLE
Update traefik to v2.11

### DIFF
--- a/src/Support/Docker.php
+++ b/src/Support/Docker.php
@@ -59,7 +59,7 @@ class Docker
         $homeDirectory = app(Filesystem::class)->getHomeDirectory();
 
         Fleet::process(
-            "docker run -d -p 8080:8080 -p 80:80 -p 443:443 --network=fleet -v /var/run/docker.sock:/var/run/docker.sock -v {$homeDirectory}/.config/mkcert:/etc/traefik --name=fleet traefik:v2.9 --api.insecure=true --providers.docker --entryPoints.web.address=:80 --entryPoints.websecure.address=:443 --providers.file.directory=/etc/traefik/conf --providers.file.watch=true",
+            "docker run -d -p 8080:8080 -p 80:80 -p 443:443 --network=fleet -v /var/run/docker.sock:/var/run/docker.sock -v {$homeDirectory}/.config/mkcert:/etc/traefik --name=fleet traefik:v2.11 --api.insecure=true --providers.docker --entryPoints.web.address=:80 --entryPoints.websecure.address=:443 --providers.file.directory=/etc/traefik/conf --providers.file.watch=true",
             true
         );
     }


### PR DESCRIPTION
Traefik v2.9 is not compatible with latest versions of Docker.
See https://community.traefik.io/t/traefik-stops-working-it-uses-old-api-version-1-24/29019/14